### PR TITLE
Included libgd in engicam-gwc image

### DIFF
--- a/recipes-images/images/engicam-gwc.bb
+++ b/recipes-images/images/engicam-gwc.bb
@@ -96,6 +96,7 @@ IMAGE_INSTALL_append = " \
 	yasdi \
 	opendnp3 \
 	libnodave \
+	gd \
 "
 
 IMAGE_INSTALL_append_icoremx6 = " \


### PR DESCRIPTION
Turned out that meta-oe already has a receipe for libgd :star_struck: 
Should be enough, right?
libjpeg,libpng and libtiff are already in.
Software compiles