### PR TITLE
Added missing  lighttpd modules

### DIFF
--- a/recipes-images/images/engicam-gwc.bb
+++ b/recipes-images/images/engicam-gwc.bb
@@ -58,6 +58,8 @@ IMAGE_INSTALL_append = " \
 	lighttpd-module-authn-file \
 	lighttpd-module-evasive \
 	lighttpd-module-usertrack \
+	lighttpd-module-setenv \
+	lighttpd-module-cgi \
 	libmicrohttpd \
 	ntpdate \
 	procps \


### PR DESCRIPTION
Added cgi and setenv, which are needed by lighttpd, otherwise cgis won't work.
I don't know ho I haven't noticed in the test env we prepared! Probably I've ported the related .so from V3.