### PR TITLE
systemd-networkd removing default conf

### DIFF
--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,5 @@
+# Removing default systemd network file that take precedence over gwc conf
+
+do_install_append() {
+  rm -f ${D}/lib/systemd/network/*
+}

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -8,6 +8,8 @@ do_install_append() {
 	ln -s /dev/null ${D}/etc/systemd/system/rpcbind.service
 	ln -s /dev/null ${D}/etc/systemd/system/ntpd.service
 	ln -s /dev/null ${D}/etc/systemd/system/rngd.service
-	ln -s /dev/null ${D}/etc/systemd/system/systemd-timesyncd.service	
+	ln -s /dev/null ${D}/etc/systemd/system/systemd-timesyncd.service
+	# Removing default systemd network conf overriding gwc conf
+	rm -f ${D}/lib/systemd/network/*
 }
 


### PR DESCRIPTION
I needed to create a second bbappend file because, only adding the rm inside `systemd_%.conf` doesn't delete `80-wired.network` that is installed by `poky/meta/recipes-core/systemd/systemd-conf_244.3.bb`

The strange thing is that I had to replicate the command in both `systemd` and `systemd-conf` to get an empty `/lib/systemd/network`, otherwise I'll end up having some of the files:

- rm in `systemd` -> Only `80-wired.network`
- rm in `systemd-conf` -> All others except `80-wired.network`

Am I doing something wrong or is the intended behaviour (each recipe install only it's own files)?
Could you please check if it's really needed to have this duplication?

Thanks :pray: 