### PR TITLE
Fix usb1-1 over-currrent error

### DIFF
--- a/recipes-kernel/linux/engicam-linux-fslc/gwcv4/0001-add-dts.patch
+++ b/recipes-kernel/linux/engicam-linux-fslc/gwcv4/0001-add-dts.patch
@@ -18,7 +18,7 @@ diff -ruN a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
 diff -ruN a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts
 --- a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts	1970-01-01 01:00:00.000000000 +0100
 +++ b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts	2020-09-23 14:01:26.743422010 +0200
-@@ -0,0 +1,467 @@
+@@ -0,0 +1,468 @@
 +/*
 + * Copyright (C) 2015 Freescale Semiconductor, Inc.
 + *
@@ -204,6 +204,7 @@ diff -ruN a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts b/arch/arm/boot/dts
 +
 +&usbotg1 {
 +	dr_mode = "host";
++ disable-over-current;
 +	status = "okay";
 +};
 +
@@ -489,7 +490,7 @@ diff -ruN a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts b/arch/arm/boot/dts
 diff -ruN a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts
 --- a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts	1970-01-01 01:00:00.000000000 +0100
 +++ b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts	2020-09-23 14:01:45.999379085 +0200
-@@ -0,0 +1,494 @@
+@@ -0,0 +1,495 @@
 +/*
 + * Copyright (C) 2015 Freescale Semiconductor, Inc.
 + *
@@ -688,6 +689,7 @@ diff -ruN a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts b/arch/arm/boot/dts
 +
 +&usbotg1 {
 +	dr_mode = "host";
++ disable-over-current;
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
Fixed in DTS by disabling the over-current signal (not wired) for USB1-1 that was generating a false alarm on every USB event