### PR TITLE
Qualcomm BG96 (Teltonika TRM250) Patch

### DIFF
--- a/recipes-kernel/linux/engicam-linux-fslc.inc
+++ b/recipes-kernel/linux/engicam-linux-fslc.inc
@@ -8,6 +8,7 @@ DEPENDS += "lzop-native bc-native linux-firmware wireless-regdb"
 SRC_URI = "git://github.com/Freescale/linux-fslc.git;branch=${SRCBRANCH} \
            file://0001-add-dts.patch \
            file://0002-Add_idscount.patch \
+           file://0003-Qualcomm-BG96-modem.patch \
            file://gen_dts.sh \
            file://defconfig"
 

--- a/recipes-kernel/linux/engicam-linux-fslc/gwcv4/0003-Qualcomm-BG96-modem.patch
+++ b/recipes-kernel/linux/engicam-linux-fslc/gwcv4/0003-Qualcomm-BG96-modem.patch
@@ -1,0 +1,17 @@
+diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
+index f7a6ac05ac57..c67eeedf4dd5 100644
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -1103,9 +1103,8 @@ static const struct usb_device_id option_ids[] = {
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_EG95, 0xff, 0xff, 0xff),
+ 	  .driver_info = NUMEP2 },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_EG95, 0xff, 0, 0) },
+-	{ USB_DEVICE_AND_INTERFACE_INFO(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_BG96, 0xff, 0xff, 0xff),
+-	  .driver_info = NUMEP2 },
+-	{ USB_DEVICE_AND_INTERFACE_INFO(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_BG96, 0xff, 0, 0) },
++	{ USB_DEVICE(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_BG96),
++	  .driver_info = RSVD(4) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_EP06, 0xff, 0xff, 0xff),
+ 	  .driver_info = RSVD(1) | RSVD(2) | RSVD(3) | RSVD(4) | NUMEP2 },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_EP06, 0xff, 0, 0) },
+  


### PR DESCRIPTION
Looks like we were a bit unlucky!
This specific driver seems to be regressed after 5.4.66.... and we have 5.4.69! :rofl: 

I've found this patch in the 5.4.x kernel branch, it's dated 2020-12-11.

In this PR i've backported the patch. Would it be worth updating to latest 5.4 or better leave as is?

Here's the refs:

- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.4.y&id=013d2d046532bbe03eb73678e23af538d503440e
- https://github.com/raspberrypi/linux/issues/3964