### PR TITLE
fix: rtl8733bu recipe to work on build env

### DIFF
--- a/recipes-kernel/rtl8733bu/rtl8733bu_0.1.bb
+++ b/recipes-kernel/rtl8733bu/rtl8733bu_0.1.bb
@@ -1,27 +1,25 @@
 SUMMARY = "RTL8733bu driver from Quectel"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://README.md;md5=06e9d5a41e8acec1af7a06452d67ee6d"
+LIC_FILES_CHKSUM = "file://README.md;md5=3bb007783e0d51c86195b4cae631dc99"
 
 inherit module
 
 S = "${WORKDIR}/git"
 
-
 DEPENDS += "bc-native"
 
-SRCREV = "3a0a44e9ab51da327cadb783ac6f2cc95f643c35"
+SRCREV = "dd9f33e9fc44b475bb44941955d7c3acba192dd1"
 SRC_URI = "git://github.com/fedepell/rtl8733bu.git;branch=master"
 
 do_compile() {
-	export CFLAGS="$CFLAGS -DDEBUG"
-	make KSRC=${STAGING_KERNEL_DIR}
+	make KSRC=${STAGING_KERNEL_DIR} KVER=${KERNEL_VERSION}
 }
 
 do_install() {
 	mkdir -p "${D}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless"
-	make install KSRC=${STAGING_KERNEL_DIR} INSTALL_MOD_PATH="${D}" MODDESTDIR="${D}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/"
+	# This module has a makefile with hardcoded depmod path, so better directly copy what's needed 
+	cp *.ko "${D}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/"
 }
-
 
 # The inherit of module.bbclass will automatically name module packages with
 # "kernel-module-" prefix as required by the oe-core build environment.


### PR DESCRIPTION
Upstream makefile has a hardcoded depmod path that doesn't work on build env.