### PR TITLE
fix: chrony conflicts with ntp-dev

### DIFF
--- a/recipes-images/images/engicam-gwc.bb
+++ b/recipes-images/images/engicam-gwc.bb
@@ -62,7 +62,6 @@ IMAGE_INSTALL_append = " \
 	lighttpd-module-cgi \
 	lighttpd-module-compress \
 	libmicrohttpd \
-	ntpdate \
 	procps \
 	xz \
 	wget \


### PR DESCRIPTION
Building SDK failed due to `ntpdate` providing `ntp-dev` which conflicts with `chrony`