### PR TITLE
gwcv4 dts: Use phy-reset-gpios instead of MDIO reset-gpio

### DIFF
--- a/recipes-kernel/linux/engicam-linux-fslc.inc
+++ b/recipes-kernel/linux/engicam-linux-fslc.inc
@@ -11,6 +11,7 @@ SRC_URI = "git://github.com/fedepell/linux-fslc.git;branch=${SRCBRANCH} \
            file://0001-add-dts.patch \
            file://0002-Add_idscount.patch \
            file://0005-ADC_support.patch \
+           file://0006-DTB_phy_reset_changes.patch \
            file://gen_dts.sh \
            file://defconfig"
 

--- a/recipes-kernel/linux/engicam-linux-fslc/gwcv4/0006-DTB_phy_reset_changes.patch
+++ b/recipes-kernel/linux/engicam-linux-fslc/gwcv4/0006-DTB_phy_reset_changes.patch
@@ -1,0 +1,71 @@
+diff -ruN a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts
+--- a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts	2025-12-21 09:44:08.088000000 +0100
++++ b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts1.dts	2025-12-24 04:10:25.560000000 +0100
+@@ -99,6 +99,9 @@
+ 	pinctrl-0 = <&pinctrl_enet1>;
+ 	phy-mode = "rmii";
+ 	phy-handle = <&ethphy0>;
++	phy-reset-post-delay = <10>;
++	phy-reset-post-duration = <10>;
++	phy-reset-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
+ 	status = "okay";
+ 
+ 	mdio {
+@@ -109,10 +112,7 @@
+ 			compatible = "ethernet-phy-ieee802.3-c22";
+ 			smsc,disable-energy-detect;
+ 			reg = <0>;
+-			reset-names = "phy0";
+-			reset-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
+-			reset-assert-us = <1000>;
+-			reset-deassert-us = <1000>;
++			status = "okay";
+ 		};
+ 	};
+ };
+diff -ruN a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts
+--- a/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts	2025-12-21 09:44:08.088000000 +0100
++++ b/arch/arm/boot/dts/microgea-mx6ull-gwcv4-dts2.dts	2025-12-24 04:10:27.900000000 +0100
+@@ -99,6 +99,9 @@
+ 	pinctrl-0 = <&pinctrl_enet1>;
+ 	phy-mode = "rmii";
+ 	phy-handle = <&ethphy0>;
++        phy-reset-post-delay = <10>;
++        phy-reset-post-duration = <10>;
++        phy-reset-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
+ 	status = "okay";
+ };
+ 
+@@ -107,6 +110,9 @@
+ 	pinctrl-0 = <&pinctrl_enet2>;
+ 	phy-mode = "rmii";
+ 	phy-handle = <&ethphy1>;
++        phy-reset-post-delay = <10>;
++        phy-reset-post-duration = <10>;
++        phy-reset-gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
+ 	status = "okay";
+ 
+ 	mdio {
+@@ -117,20 +123,14 @@
+ 			compatible = "ethernet-phy-ieee802.3-c22";
+ 			smsc,disable-energy-detect;
+ 			reg = <0>;
+-			reset-names = "phy0";
+-			reset-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
+-			reset-assert-us = <1000>;
+-			reset-deassert-us = <1000>;
++			status = "okay";
+ 		};
+ 
+ 		ethphy1: ethernet-phy@1 {
+ 			compatible = "ethernet-phy-ieee802.3-c22";
+ 			smsc,disable-energy-detect;
+ 			reg = <1>;
+-			reset-names = "phy1";
+-			reset-gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
+-			reset-assert-us = <1000>;
+-			reset-deassert-us = <1000>;
++			status = "okay";
+ 		};
+ 	};
+ };


### PR DESCRIPTION
This makes PHY detection much more reliable as MDIO one seems to be very timing (and HW/kernel version) dependant as it may occour in different moments of the boot.